### PR TITLE
radiotap and wlan headers support, v0.1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,13 +7,17 @@ nprint_SOURCES = src/conf.cpp src/nprint.cpp src/io/file_parser.cpp src/io/file_
 				src/packet/packet_header.cpp src/packet/payload.cpp src/io/pcap_parser.cpp \
 				src/io/stringfile_parser.cpp src/packet/superpacket.cpp src/packet/tcp_header.cpp \
 				src/packet/udp_header.cpp src/io/nprint_parser.cpp \
-				src/packet/ethernet_header.cpp src/stats.cpp \
+				src/packet/ethernet_header.cpp \
+				src/packet/wlan_header.cpp src/packet/radiotap_header.cpp \
+				src/stats.cpp \
 				include/conf.hpp include/io/file_parser.hpp include/io/file_writer.hpp \
 				include/packet/icmp_header.hpp include/packet/ipv4_header.hpp include/packet/ipv6_header.hpp \
 				include/packet/packet_header.hpp include/packet/payload.hpp include/io/pcap_parser.hpp \
 				include/io/stringfile_parser.hpp include/packet/superpacket.hpp include/packet/tcp_header.hpp \
 				include/packet/udp_header.hpp include/io/nprint_parser.hpp \
-				include/packet/ethernet_header.hpp  include/stats.hpp
+				include/packet/ethernet_header.hpp \
+				include/packet/wlan_header.hpp include/packet/radiotap_header.hpp \
+				include/stats.hpp
 
 AM_CPPFLAGS = -Iinclude/ -Iinclude/io/ -Iinclude/packet/ -pedantic -Wall -std=gnu++11 $(WRAPPER_CPPFLAGS)
 AM_LDFLAGS = $(WRAPPER_LDFLAGS)

--- a/include/conf.hpp
+++ b/include/conf.hpp
@@ -21,6 +21,8 @@ class Config {
   public:
     Config();
     /* Protocol flags */
+    uint8_t radiotap;
+    uint8_t wlan;
     uint8_t eth;
     uint8_t ipv4;
     uint8_t ipv6;
@@ -28,6 +30,11 @@ class Config {
     uint8_t udp;
     uint8_t icmp;
     uint32_t payload;
+
+    /* Link-layer types */
+    uint8_t wireless;
+    uint8_t wired;
+    void set_link_layer_type();
 
     /*  Output modification */
     uint8_t stats;
@@ -47,11 +54,12 @@ class Config {
     char *infile;
     char *ip_file;
     char *outfile;
-    std::map<uint8_t, std::string> index_map = {{0, "src_ip"},
+    std::map<int8_t, std::string> index_map = {{0, "src_ip"},
                                                 {1, "dst_ip"},
                                                 {2, "src_prt"},
                                                 {3, "dst_prt"},
-                                                {4, "flow"}};
+                                                {4, "flow"},
+                                                {5, "tx_mac"}};
 };
 
 #endif

--- a/include/conf.hpp
+++ b/include/conf.hpp
@@ -31,11 +31,6 @@ class Config {
     uint8_t icmp;
     uint32_t payload;
 
-    /* Link-layer types */
-    uint8_t wireless;
-    uint8_t wired;
-    void set_link_layer_type();
-
     /*  Output modification */
     uint8_t stats;
     uint8_t csv;

--- a/include/io/file_parser.hpp
+++ b/include/io/file_parser.hpp
@@ -46,6 +46,7 @@ class FileParser {
     Stats stat;
     Config config;
     FileWriter *fw;
+    uint32_t linktype;
     void write_output(SuperPacket *sp);
     //static void signal_handler(int signum);
 

--- a/include/io/file_writer.hpp
+++ b/include/io/file_writer.hpp
@@ -17,6 +17,8 @@
 #include <sys/types.h>
 
 #include "conf.hpp"
+#include "radiotap_header.hpp"
+#include "wlan_header.hpp"
 #include "ethernet_header.hpp"
 #include "icmp_header.hpp"
 #include "ipv4_header.hpp"

--- a/include/io/pcap_parser.hpp
+++ b/include/io/pcap_parser.hpp
@@ -36,7 +36,6 @@ class PCAPParser : public FileParser {
 
   private:
     struct timeval mrt;
-    uint32_t linktype;
     std::vector<std::string> to_fill;
     
     pcap_t *get_pcap_handle();

--- a/include/packet/radiotap_header.hpp
+++ b/include/packet/radiotap_header.hpp
@@ -13,7 +13,7 @@
 #define SIZE_RADIOTAP_HEADER_BITSTRING 56
 
 struct radiotap_header {
-    uint8_t  radiotap_data[56];	/* all bytes for radiotap_data 	*/
+    uint8_t* radiotap_data;	/* all bytes for radiotap_data 	*/
 };
 
 class RadiotapHeader : public PacketHeader {

--- a/include/packet/radiotap_header.hpp
+++ b/include/packet/radiotap_header.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright nPrint 2021
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef RADIOTAP_HEADER
+#define RADIOTAP_HEADER
+
+#include "packet_header.hpp"
+
+#define SIZE_RADIOTAP_HEADER_BITSTRING 56
+
+struct radiotap_header {
+    uint8_t  radiotap_data[56];	/* all bytes for radiotap_data 	*/
+};
+
+class RadiotapHeader : public PacketHeader {
+    public:
+        /* Required Functions */
+        void* get_raw();
+        void set_raw(void *raw);
+        void print_header(FILE *out);
+        uint32_t get_header_len();
+        void get_bitstring(std::vector<int8_t>  &to_fill, int8_t fill_with);
+        void get_bitstring_header(std::vector<std::string> &to_fill);
+    private:
+        struct radiotap_header* raw = NULL;
+};
+
+#endif

--- a/include/packet/superpacket.hpp
+++ b/include/packet/superpacket.hpp
@@ -15,6 +15,8 @@
 #include <arpa/inet.h>
 
 #include "conf.hpp"
+#include "radiotap_header.hpp"
+#include "wlan_header.hpp"
 #include "ethernet_header.hpp"
 #include "icmp_header.hpp"
 #include "ipv4_header.hpp"
@@ -25,9 +27,10 @@
 
 class SuperPacket {
   public:
-    SuperPacket(void *pkt, uint32_t max_payload_len);
+    SuperPacket(void *pkt, uint32_t max_payload_len, Config *c);
     std::string get_port(bool src);
     std::string get_ip_address(bool src);
+    std::string get_tx_mac_address();
     void print_packet(FILE *out);
     bool check_parseable() {
         return parseable;
@@ -35,6 +38,7 @@ class SuperPacket {
     std::tuple<uint8_t, uint8_t> get_packet_type();
     void get_bitstring(Config *c, std::vector<int8_t> &to_fill);
     std::string get_index(Config *c);
+    Config *config;
 
   private:
     bool process_v4(void *pkt);
@@ -42,6 +46,8 @@ class SuperPacket {
 
     bool parseable;
     uint32_t max_payload_len;
+    RadiotapHeader radiotap_header;
+    WlanHeader wlan_header;
     EthHeader ethernet_header;
     IPv4Header ipv4_header;
     IPv6Header ipv6_header;

--- a/include/packet/superpacket.hpp
+++ b/include/packet/superpacket.hpp
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
+#include <pcap.h>
 
 #include "conf.hpp"
 #include "radiotap_header.hpp"
@@ -27,7 +28,7 @@
 
 class SuperPacket {
   public:
-    SuperPacket(void *pkt, uint32_t max_payload_len, Config *c);
+    SuperPacket(void *pkt, uint32_t max_payload_len, uint32_t linktype);
     std::string get_port(bool src);
     std::string get_ip_address(bool src);
     std::string get_tx_mac_address();
@@ -38,7 +39,6 @@ class SuperPacket {
     std::tuple<uint8_t, uint8_t> get_packet_type();
     void get_bitstring(Config *c, std::vector<int8_t> &to_fill);
     std::string get_index(Config *c);
-    Config *config;
 
   private:
     bool process_v4(void *pkt);

--- a/include/packet/wlan_header.hpp
+++ b/include/packet/wlan_header.hpp
@@ -10,6 +10,7 @@
 
 #include "packet_header.hpp"
 
+// TODO: we only parse the first 10 bytes at this time 
 #define SIZE_WLAN_HEADER_BITSTRING 10
 
 struct wlan_header {

--- a/include/packet/wlan_header.hpp
+++ b/include/packet/wlan_header.hpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright nPrint 2021
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef WLAN_HEADER
+#define WLAN_HEADER
+
+#include "packet_header.hpp"
+
+#define SIZE_WLAN_HEADER_BITSTRING 10
+
+struct wlan_header {
+    uint8_t  type;
+    uint8_t  flag;
+    uint16_t duration;
+    uint8_t  rx_addr[6];
+    uint8_t  tx_addr[6];
+};
+
+class WlanHeader : public PacketHeader {
+    public:
+        /* Required Functions */
+        void* get_raw();
+        void set_raw(void *raw);
+        void print_header(FILE *out);
+        uint32_t get_header_len();
+        void get_bitstring(std::vector<int8_t>  &to_fill, int8_t fill_with);
+        void get_bitstring_header(std::vector<std::string> &to_fill);
+
+        std::string get_tx_mac();
+
+    private:
+        struct wlan_header* raw = NULL;
+};
+
+#endif

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -22,8 +22,6 @@ Config::Config() {
     this->relative_timestamps = 0;
     this->pcap = 0;
     this->csv = 0;
-    this->wireless = 0;
-    this->wired = 0;
     this->stats = 0;
     this->nprint = 0;
     this->verbose = 0;
@@ -35,13 +33,4 @@ Config::Config() {
     this->ip_file = NULL;
     this->outfile = NULL;
     this->device = NULL;
-}
-
-void Config::set_link_layer_type() {
-    if ((this->radiotap + this->wlan) > 0) {
-        this->wireless = 1;
-    }
-    if ((this->eth + this->ipv4 + this->ipv6 + this->tcp + this->udp + this->icmp) > 0) {
-        this->wired = 1;
-    }
 }

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -7,6 +7,8 @@
 #include "conf.hpp"
 
 Config::Config() {
+    this->radiotap = 0;
+    this->wlan = 0;
     this->eth = 0;
     this->ipv4 = 0;
     this->ipv6 = 0;
@@ -20,6 +22,8 @@ Config::Config() {
     this->relative_timestamps = 0;
     this->pcap = 0;
     this->csv = 0;
+    this->wireless = 0;
+    this->wired = 0;
     this->stats = 0;
     this->nprint = 0;
     this->verbose = 0;
@@ -31,4 +35,13 @@ Config::Config() {
     this->ip_file = NULL;
     this->outfile = NULL;
     this->device = NULL;
+}
+
+void Config::set_link_layer_type() {
+    if ((this->radiotap + this->wlan) > 0) {
+        this->wireless = 1;
+    }
+    if ((this->eth + this->ipv4 + this->ipv6 + this->tcp + this->udp + this->icmp) > 0) {
+        this->wired = 1;
+    }
 }

--- a/src/io/file_parser.cpp
+++ b/src/io/file_parser.cpp
@@ -46,7 +46,7 @@ SuperPacket *FileParser::process_packet(void *pkt) {
     uint8_t network_layer, transport_layer;
 
     to_fill.clear();
-    sp = new SuperPacket(pkt, config.payload);
+    sp = new SuperPacket(pkt, config.payload, &config);
     parseable = sp->check_parseable();
     if (!parseable) {
         delete sp;

--- a/src/io/file_parser.cpp
+++ b/src/io/file_parser.cpp
@@ -46,7 +46,7 @@ SuperPacket *FileParser::process_packet(void *pkt) {
     uint8_t network_layer, transport_layer;
 
     to_fill.clear();
-    sp = new SuperPacket(pkt, config.payload, &config);
+    sp = new SuperPacket(pkt, config.payload, linktype);
     parseable = sp->check_parseable();
     if (!parseable) {
         delete sp;

--- a/src/io/file_writer.cpp
+++ b/src/io/file_writer.cpp
@@ -63,6 +63,8 @@ std::vector<std::string>
 FileWriter::build_bitstring_header(std::vector<std::string> header) {
     uint32_t i, prefix_len;
     Payload p;
+    RadiotapHeader r;
+    WlanHeader w;
     EthHeader e;
     IPv4Header v4;
     IPv6Header v6;
@@ -75,6 +77,10 @@ FileWriter::build_bitstring_header(std::vector<std::string> header) {
     /* Need to inform the payload of the max len */
     p.set_info(0, config.payload);
 
+    if (config.radiotap == 1)
+        r.get_bitstring_header(header);
+    if (config.wlan == 1)
+        w.get_bitstring_header(header);
     if (config.eth == 1)
         e.get_bitstring_header(header);
     if (config.ipv4 == 1)

--- a/src/nprint.cpp
+++ b/src/nprint.cpp
@@ -211,7 +211,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
         break;
     case 'O':
         arguments->output_index = atoi(arg);
-        if (arguments->output_index > 4 || arguments->output_index < 0) {
+        if (arguments->output_index > 5 || arguments->output_index < 0) {
             fprintf(stderr, "invald index configuration, exiting\n");
             exit(3);
         }
@@ -235,28 +235,10 @@ int main(int argc, char **argv) {
 
     /* parse args */
     argp_parse(&argp, argc, argv, 0, 0, &config);
-    config.set_link_layer_type();
 
     /* File Writer handles writing nPrints */
     fw = new FileWriter;
     fw->set_conf(config);
-
-    /* The upper layers (Network-layer and Transport-layer) of wireless packets are encrypted.
-     * We may add decription support in a future version. */ 
-    if ((config.wireless + config.wired) > 1) {
-        fprintf(stderr, "Wireless packets can only use {-r, -w} protocol flags.\n");
-        exit(1);
-    }
-
-    /* The default index of wireless packest is tx_mac,
-     * The default index of wired packet is src_ip. */
-    // if (config.index == -1) {
-    //     if (config.wireless == 1) {
-    //         config.index = 5;
-    //     } else if (config.wired == 1) {
-    //         config.index = 0;
-    //     }
-    // } 
 
     /* No infile means processing live traffic. There is a way to delete this
      * code, but this is verbose */

--- a/src/packet/radiotap_header.cpp
+++ b/src/packet/radiotap_header.cpp
@@ -24,7 +24,7 @@ void RadiotapHeader::print_header(FILE *out) {
 }
 
 uint32_t RadiotapHeader::get_header_len() {
-    return 56;
+    return SIZE_RADIOTAP_HEADER_BITSTRING;
 }
 
 void RadiotapHeader::get_bitstring(std::vector<int8_t> &to_fill, int8_t fill_with) {

--- a/src/packet/radiotap_header.cpp
+++ b/src/packet/radiotap_header.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright nPrint 2021
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "radiotap_header.hpp"
+
+void *RadiotapHeader::get_raw() {
+    return (void *) raw;
+}
+
+void RadiotapHeader::set_raw(void *raw) {
+    this->raw = (struct radiotap_header *) raw;
+}
+
+void RadiotapHeader::print_header(FILE *out) {
+    if (raw == NULL) {
+        fprintf(out, "RadiotapHeader: raw data not set\n");
+    } else {
+        fprintf(out, "RadiotapHeader: %d bytes\n", get_header_len());
+    }
+}
+
+uint32_t RadiotapHeader::get_header_len() {
+    return 56;
+}
+
+void RadiotapHeader::get_bitstring(std::vector<int8_t> &to_fill, int8_t fill_with) {
+    make_bitstring(SIZE_RADIOTAP_HEADER_BITSTRING, raw, to_fill, fill_with);
+}
+
+void RadiotapHeader::get_bitstring_header(std::vector<std::string> &to_fill) {
+    std::vector<std::tuple<std::string, uint32_t> > v;
+
+    v.push_back(std::make_tuple("radiotap_reversion", 1 * 8));
+    v.push_back(std::make_tuple("radiotap_pad0", 1 * 8));
+    v.push_back(std::make_tuple("radiotap_len", 2 * 8));
+    v.push_back(std::make_tuple("radiotap_present", 12 * 8));
+    v.push_back(std::make_tuple("radiotap_mactimestamp", 8 * 8));
+    v.push_back(std::make_tuple("radiotap_flags", 1 * 8));
+    v.push_back(std::make_tuple("radiotap_rate", 1 * 8));
+    v.push_back(std::make_tuple("radiotap_channel", 2 * 8));
+    v.push_back(std::make_tuple("radiotap_channelflags", 2 * 8));
+    v.push_back(std::make_tuple("radiotap_antennasignal", 1 * 8));
+    v.push_back(std::make_tuple("radiotap_pad1", 1 * 8));
+    v.push_back(std::make_tuple("radiotap_rxflags", 2 * 8));
+    v.push_back(std::make_tuple("radiotap_pad2", 6 * 8));
+    v.push_back(std::make_tuple("radiotap_timestamp", 12 * 8));
+    v.push_back(std::make_tuple("radiotap_antennas", 4 * 8));
+
+    PacketHeader::make_bitstring_header(v, to_fill);
+}

--- a/src/packet/superpacket.cpp
+++ b/src/packet/superpacket.cpp
@@ -9,6 +9,8 @@
 
 void SuperPacket::print_packet(FILE *out) {
     fprintf(out, "Superpacket {\n");
+    radiotap_header.print_header(out);
+    wlan_header.print_header(out);
     ethernet_header.print_header(out);
     ipv4_header.print_header(out);
     ipv6_header.print_header(out);
@@ -19,30 +21,43 @@ void SuperPacket::print_packet(FILE *out) {
     fprintf(out, "}\n");
 }
 
-SuperPacket::SuperPacket(void *pkt, uint32_t max_payload_len) {
+SuperPacket::SuperPacket(void *pkt, uint32_t max_payload_len, Config *c) {
+    struct radiotap_header *radiotaph;
+    struct wlan_header * wlanh;
+
     struct ip *ipv4h;
     struct ether_header *eth;
 
+    this->config = c;
+
     parseable = true;
 
-    this->max_payload_len = max_payload_len;
-    eth = (struct ether_header *)pkt;
+    if (c->wireless == 1) {
+        radiotaph = (struct radiotap_header *) pkt;
+        radiotap_header.set_raw(radiotaph);
 
-    /* Check if packet has an ethernet header */
-    if ((ntohs(eth->ether_type) == ETHERTYPE_IP) ||
-        ((ntohs(eth->ether_type) == 0x86DD))) {
-        ethernet_header.set_raw(eth);
-        ipv4h = (struct ip *)&eth[1];
-    } else {
-        ipv4h = (struct ip *)pkt;
-    }
+        wlanh = (struct wlan_header *) &radiotaph[1]; 
+        wlan_header.set_raw(wlanh);        
+    } else if (c->wired == 1) {
+        this->max_payload_len = max_payload_len;
+        eth = (struct ether_header *)pkt;
 
-    if (ipv4h->ip_v == 4) {
-        parseable = process_v4((void *)ipv4h);
-    } else if (ipv4h->ip_v == 6) {
-        parseable = process_v6((void *)ipv4h);
-    } else {
-        parseable = false;
+        /* Check if packet has an ethernet header */
+        if ((ntohs(eth->ether_type) == ETHERTYPE_IP) ||
+            ((ntohs(eth->ether_type) == 0x86DD))) {
+            ethernet_header.set_raw(eth);
+            ipv4h = (struct ip *)&eth[1];
+        } else {
+            ipv4h = (struct ip *)pkt;
+        }
+
+        if (ipv4h->ip_v == 4) {
+            parseable = process_v4((void *)ipv4h);
+        } else if (ipv4h->ip_v == 6) {
+            parseable = process_v6((void *)ipv4h);
+        } else {
+            parseable = false;
+        }
     }
 }
 
@@ -138,6 +153,10 @@ bool SuperPacket::process_v6(void *pkt) {
 }
 
 void SuperPacket::get_bitstring(Config *c, std::vector<int8_t> &to_fill) {
+    if (c->radiotap == 1)
+        radiotap_header.get_bitstring(to_fill, c->fill_with);
+    if (c->wlan == 1)
+        radiotap_header.get_bitstring(to_fill, c->fill_with);
     if (c->eth == 1)
         ethernet_header.get_bitstring(to_fill, c->fill_with);
     if (c->ipv4 == 1)
@@ -188,6 +207,10 @@ std::string SuperPacket::get_index(Config *c) {
             rv += std::string("_") + "NULL";
         }
     }
+    /* Wlan TX Mac Address */
+    else if (c->index == 5) {
+        rv = get_tx_mac_address();
+    }
 
     return rv;
 }
@@ -215,6 +238,14 @@ std::string SuperPacket::get_port(bool src) {
         return tcp_header.get_port(src);
     } else if (udp_header.get_raw() != NULL) {
         return udp_header.get_port(src);
+    } else {
+        return "NULL";
+    }
+}
+
+std::string SuperPacket::get_tx_mac_address() {
+    if(wlan_header.get_raw() != NULL) {
+        return wlan_header.get_tx_mac();
     } else {
         return "NULL";
     }

--- a/src/packet/wlan_header.cpp
+++ b/src/packet/wlan_header.cpp
@@ -31,7 +31,7 @@ void WlanHeader::print_header(FILE *out) {
 }
 
 uint32_t WlanHeader::get_header_len() {
-    return 10;
+    return SIZE_WLAN_HEADER_BITSTRING;  // TODO: we only parse the first 10 bytes at this time 
 }
 
 void WlanHeader::get_bitstring(std::vector<int8_t> &to_fill, int8_t fill_with) {
@@ -40,8 +40,8 @@ void WlanHeader::get_bitstring(std::vector<int8_t> &to_fill, int8_t fill_with) {
 
 std::string WlanHeader::get_tx_mac() {
     switch (raw->type) {
-        // TODO: this list may not complete
-        case 0xc4:  // CTS ClearTo Send
+        //  3 subtypes have no TX max address
+        case 0xc4:  // CTS Clear To Send
         case 0xd4:  // ACK
         case 0xe4:  // CF-End
             return "None";

--- a/src/packet/wlan_header.cpp
+++ b/src/packet/wlan_header.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright nPrint 2021
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "wlan_header.hpp"
+
+void *WlanHeader::get_raw() {
+    return (void *) raw;
+}
+
+void WlanHeader::set_raw(void *raw) {
+    this->raw = (struct wlan_header *) raw;
+}
+
+void WlanHeader::print_header(FILE *out) {
+    if(raw == NULL) {
+        printf("WlanHeader: raw data not set\n");
+    } else {
+        fprintf(out, "Wlan Header: rx-addr: %02x:%02x:%02x:%02x:%02x:%02x, ",
+               raw->rx_addr[0],
+               raw->rx_addr[1],
+               raw->rx_addr[2],
+               raw->rx_addr[3],
+               raw->rx_addr[4],
+               raw->rx_addr[5]);
+        fprintf(out, "wlan-type: %u\n", raw->type);
+    }
+}
+
+uint32_t WlanHeader::get_header_len() {
+    return 10;
+}
+
+void WlanHeader::get_bitstring(std::vector<int8_t> &to_fill, int8_t fill_with) {
+    make_bitstring(SIZE_WLAN_HEADER_BITSTRING, raw, to_fill, fill_with);
+}
+
+std::string WlanHeader::get_tx_mac() {
+    switch (raw->type) {
+        // TODO: this list may not complete
+        case 0xc4:  // CTS ClearTo Send
+        case 0xd4:  // ACK
+        case 0xe4:  // CF-End
+            return "None";
+        default:
+            char buf[18];
+            sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x",
+              raw->tx_addr[0],
+              raw->tx_addr[1],
+              raw->tx_addr[2],
+              raw->tx_addr[3],
+              raw->tx_addr[4],
+              raw->tx_addr[5]);
+            return buf;
+    }
+}
+
+void WlanHeader::get_bitstring_header(std::vector<std::string> &to_fill) {
+    std::vector<std::tuple<std::string, uint32_t> > v;
+    v.push_back(std::make_tuple("wlan_type", 1 * 8));
+    v.push_back(std::make_tuple("wlan_flag", 1 * 8));
+    v.push_back(std::make_tuple("wlan_duration", 2 * 8));
+    v.push_back(std::make_tuple("wlan_rx_addr", 6 * 8));
+
+    PacketHeader::make_bitstring_header(v, to_fill);
+}


### PR DESCRIPTION
Hi Jordan, as we discussed several weeks before, I added the basic code for nPrint to support `radiotap` header and the first `10` bytes of the `wlan` header.

I try not to modify or interfere with any of your existing code, but here are two modifications related to existing code:
- At the `nprint.cpp`, the code claimed that if the `config.index` is not set, by default is `0`, i.e.,  `src_ip`. But you actually haven't implemented it. Without an explicit state `-O` option, the output `npt` file will have no indexes.  I set the default `index` to `-1` at config construct, and assign the default value for both wired and wireless packets at the `nprint` main function.

https://github.com/kaiyuhou/nprint/blob/29a44f89a98bd093eea3be2fc1d55fed9b75854c/src/conf.cpp#L31
https://github.com/kaiyuhou/nprint/blob/29a44f89a98bd093eea3be2fc1d55fed9b75854c/src/nprint.cpp#L251-L259

- I added a `*Config` point in the SuperPacket class for easy distinguishing the wired and wireless packet (I am not sure if you agree with this design or not). Your implementation of `SuperPacket::get_bitstring` and `SuperPacket::get_index` function actually also used the `*Config` point as a function parameter, I would suggest also change them to use the member point.

https://github.com/kaiyuhou/nprint/blob/29a44f89a98bd093eea3be2fc1d55fed9b75854c/include/packet/superpacket.hpp#L30
https://github.com/kaiyuhou/nprint/blob/29a44f89a98bd093eea3be2fc1d55fed9b75854c/include/packet/superpacket.hpp#L39-L40

Another small issue, the version number configure file does not up to date to meet the version number claimed at the latest repo. But I didn't correct them in this commit.