### PR TITLE
Fix macOS build instructions for argp-standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,55 @@ For a project overview, installation information, and detailed usage information
 
 `sudo apt-get install libpcap-dev`
 
-### Install dependencies on Mac OS
+### Install dependencies on macOS
 
-`brew install argp-standalone`
+```bash
+brew install argp-standalone autoconf automake libtool
+```
 
 ## Installation
 
-1. Download the latest release tar [here](https://github.com/nprint/pcapml/releases/)
-2. Extract the tar `tar -xvf [pcapml-version.tar.gz]`
-3. `cd [pcapml-directory]`
+### Building from source (latest development version)
 
-2. `./configure && make && sudo make install`
+```bash
+git clone https://github.com/nprint/nprint.git
+cd nprint
+autoreconf -i
+```
+
+**On Debian/Linux:**
+```bash
+./configure
+make
+sudo make install
+```
+
+**On macOS:**
+```bash
+./configure CPPFLAGS="-I/opt/homebrew/opt/argp-standalone/include" LDFLAGS="-L/opt/homebrew/opt/argp-standalone/lib"
+make
+sudo make install
+```
+
+### Installing from release tarball
+
+1. Download the latest release tar [here](https://github.com/nprint/nprint/releases/)
+2. Extract the tar `tar -xvf [nprint-version.tar.gz]`
+3. `cd [nprint-directory]`
+
+**On Debian/Linux:**
+```bash
+./configure
+make
+sudo make install
+```
+
+**On macOS:**
+```bash
+./configure CPPFLAGS="-I/opt/homebrew/opt/argp-standalone/include" LDFLAGS="-L/opt/homebrew/opt/argp-standalone/lib"
+make
+sudo make install
+```
 
 ## Citing nPrint
 


### PR DESCRIPTION
## Summary

This PR fixes the macOS build instructions to properly handle the `argp-standalone` dependency. 

Fixes #48

## Changes

- Updated README.md with proper `configure` command for macOS that passes `argp-standalone` include and library paths via `CPPFLAGS` and `LDFLAGS`
- Added `autoconf`, `automake`, and `libtool` to the macOS dependency installation instructions (required for building from source)
- Reorganized installation section to clearly separate Linux and macOS build steps
- Added instructions for both building from source (git clone) and from release tarballs

## Why This Approach

The previous instructions didn't account for the fact that macOS (via Homebrew) installs `argp-standalone` in a non-standard location that the compiler doesn't search by default. 

Instead of manually editing the generated Makefile (which gets overwritten on reconfigure), this approach passes the proper paths to the `configure` script, which generates the Makefile correctly from the start. This follows standard autotools best practices.

## Testing

Successfully built and installed nprint on macOS Sequoia (Apple Silicon) using these instructions.